### PR TITLE
Always store thumbnails as JPEG 99662722

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -1,5 +1,7 @@
 module Technoweenie # :nodoc:
   module AttachmentFu # :nodoc:
+    THUMBNAIL_FORMAT = 'JPEG'
+
     @@default_processors = %w(ImageScience Rmagick MiniMagick Gd2 CoreImage)
     @@tempfile_path      = File.join(Rails.root, 'tmp', 'attachment_fu')
     @@content_types      = [
@@ -546,6 +548,7 @@ module Technoweenie # :nodoc:
           if (!respond_to?(:parent_id) || parent_id.nil?) && attachment_options[:resize_to] # parent image
             resize_image(img, attachment_options[:resize_to])
           elsif thumbnail_resize_options # thumbnail
+            img.format(THUMBNAIL_FORMAT)
             resize_image(img, thumbnail_resize_options)
           end
         end

--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -311,23 +311,28 @@ module Technoweenie # :nodoc:
         end
         "#{basename}_#{thumbnail}#{ext}"
       end
+      def jpeg_thumbnail_name_for(thumbnail = nil)
+        return filename if thumbnail.blank?
+        basename = filename.gsub(/\.\w+$/, '')
+        "#{basename}_#{thumbnail}.jpeg"
+      end
 
       # Generate the thumbnails for the picture
       def generate_thumbnails
         if respond_to?(:process_attachment_with_processing, true) && thumbnailable? && !attachment_options[:thumbnails].blank? && parent_id.nil?
           temp_file = temp_path || create_temp_file
-          attachment_options[:thumbnails].each { |suffix, size| create_or_update_thumbnail temp_file, suffix, *size }
+          attachment_options[:thumbnails].each { |suffix, size| create_or_update_thumbnail_as_jpeg temp_file, suffix, *size }
         end
       end
 
       # Creates or updates the thumbnail for the current attachment.
-      def create_or_update_thumbnail(temp_file, file_name_suffix, *size)
+      def create_or_update_thumbnail_as_jpeg(temp_file, file_name_suffix, *size)
         thumbnailable? || raise(ThumbnailError.new("Can't create a thumbnail if the content type is not an image or there is no parent_id column"))
         find_or_initialize_thumbnail(file_name_suffix).tap do |thumb|
           thumb.temp_paths.unshift temp_file
           thumb.send(:assign_attributes, {
-            :content_type             => content_type,
-            :filename                 => thumbnail_name_for(file_name_suffix),
+            :content_type             => 'image/jpeg',
+            :filename                 => jpeg_thumbnail_name_for(file_name_suffix),
             :thumbnail_resize_options => size
           }, :without_protection => true)
           callback_with_args :before_thumbnail_saved, thumb

--- a/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
@@ -3,6 +3,8 @@ module Technoweenie # :nodoc:
   module AttachmentFu # :nodoc:
     module Processors
       module MiniMagickProcessor
+        IMAGE_FORMAT = 'JPEG'
+
         def self.included(base)
           base.send :extend, ClassMethods
           base.alias_method_chain :process_attachment, :processing
@@ -28,6 +30,7 @@ module Technoweenie # :nodoc:
         def process_attachment_with_processing
           return unless process_attachment_without_processing
           with_image do |img|
+            img.format(IMAGE_FORMAT)
             resize_image_or_thumbnail! img
             self.width = img[:width] if respond_to?(:width)
             self.height = img[:height] if respond_to?(:height)
@@ -38,14 +41,9 @@ module Technoweenie # :nodoc:
         # Performs the actual resizing operation for a thumbnail
         def resize_image(img, size)
           size = size.first if size.is_a?(Array) && size.length == 1
-          format = img[:format]
+          format = IMAGE_FORMAT
           img.combine_options do |commands|
             commands.strip unless attachment_options[:keep_profile]
-
-            # GIF is not handled correctly, so we move to PNG, as in other processors…
-            if format == 'GIF'
-              img.format('PNG')
-            end
 
             if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
               if size.is_a?(Fixnum)
@@ -105,7 +103,7 @@ module Technoweenie # :nodoc:
               end
 
               # don not resize if image is not as height or width then thumbnail
-              if image_width < thumb_width or image_height < thumb_height                   
+              if image_width < thumb_width or image_height < thumb_height
                   commands.background('#ffffff')
                   commands.gravity('center')
                   commands.extent(size)
@@ -142,7 +140,7 @@ module Technoweenie # :nodoc:
             command = "#{thumb_width}x#{image_height}+#{offset}+0"
 
           # normal thumbnail generation
-          # calculate height and offset y, width is fixed                 
+          # calculate height and offset y, width is fixed
           elsif (image_aspect <= thumb_aspect or image_width < thumb_width) and image_height > thumb_height
             height = image_width / thumb_aspect
             offset = (image_height / 2) - (height / 2)

--- a/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
@@ -3,7 +3,6 @@ module Technoweenie # :nodoc:
   module AttachmentFu # :nodoc:
     module Processors
       module MiniMagickProcessor
-        IMAGE_FORMAT = 'JPEG'
 
         def self.included(base)
           base.send :extend, ClassMethods
@@ -30,7 +29,6 @@ module Technoweenie # :nodoc:
         def process_attachment_with_processing
           return unless process_attachment_without_processing
           with_image do |img|
-            img.format(IMAGE_FORMAT)
             resize_image_or_thumbnail! img
             self.width = img[:width] if respond_to?(:width)
             self.height = img[:height] if respond_to?(:height)
@@ -41,7 +39,7 @@ module Technoweenie # :nodoc:
         # Performs the actual resizing operation for a thumbnail
         def resize_image(img, size)
           size = size.first if size.is_a?(Array) && size.length == 1
-          format = IMAGE_FORMAT
+          format = AttachmentFu::THUMBNAIL_FORMAT
           img.combine_options do |commands|
             commands.strip unless attachment_options[:keep_profile]
 


### PR DESCRIPTION
When an image is uploaded on radio and thumbnails are generated, they should always be converted to JPEG. The original should be kept in PNG or whatever format it is uploaded in.

https://www.pivotaltracker.com/story/show/99662722
